### PR TITLE
Add -User tables for Water and Sewer modules

### DIFF
--- a/migrations/main/2019-02-08-add-water-sewer-user-tables.sql
+++ b/migrations/main/2019-02-08-add-water-sewer-user-tables.sql
@@ -1,0 +1,910 @@
+CREATE TABLE "SewerDiversionUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_01" ("ID");
+
+CREATE TABLE "SewerDiversionUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_02" ("ID");
+
+CREATE TABLE "SewerDiversionUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_03" ("ID");
+
+CREATE TABLE "SewerDiversionUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_04" ("ID");
+
+CREATE TABLE "SewerDiversionUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_05" ("ID");
+
+CREATE TABLE "SewerDiversionUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_06" ("ID");
+
+CREATE TABLE "SewerDiversionUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_07" ("ID");
+
+CREATE TABLE "SewerDiversionUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_08" ("ID");
+
+CREATE TABLE "SewerDiversionUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_09" ("ID");
+
+CREATE TABLE "SewerDiversionUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerDiversionUser_10" ("ID");
+
+CREATE TABLE "SewerGravityUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_01" ("ID");
+
+CREATE TABLE "SewerGravityUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_02" ("ID");
+
+CREATE TABLE "SewerGravityUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_03" ("ID");
+
+CREATE TABLE "SewerGravityUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_04" ("ID");
+
+CREATE TABLE "SewerGravityUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_05" ("ID");
+
+CREATE TABLE "SewerGravityUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_06" ("ID");
+
+CREATE TABLE "SewerGravityUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_07" ("ID");
+
+CREATE TABLE "SewerGravityUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_08" ("ID");
+
+CREATE TABLE "SewerGravityUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_09" ("ID");
+
+CREATE TABLE "SewerGravityUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerGravityUser_10" ("ID");
+
+CREATE TABLE "SewerPumpUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_01" ("ID");
+
+CREATE TABLE "SewerPumpUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_02" ("ID");
+
+CREATE TABLE "SewerPumpUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_03" ("ID");
+
+CREATE TABLE "SewerPumpUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_04" ("ID");
+
+CREATE TABLE "SewerPumpUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_05" ("ID");
+
+CREATE TABLE "SewerPumpUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_06" ("ID");
+
+CREATE TABLE "SewerPumpUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_07" ("ID");
+
+CREATE TABLE "SewerPumpUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_08" ("ID");
+
+CREATE TABLE "SewerPumpUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_09" ("ID");
+
+CREATE TABLE "SewerPumpUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerPumpUser_10" ("ID");
+
+CREATE TABLE "SewerRisingUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_01" ("ID");
+
+CREATE TABLE "SewerRisingUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_02" ("ID");
+
+CREATE TABLE "SewerRisingUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_03" ("ID");
+
+CREATE TABLE "SewerRisingUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_04" ("ID");
+
+CREATE TABLE "SewerRisingUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_05" ("ID");
+
+CREATE TABLE "SewerRisingUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_06" ("ID");
+
+CREATE TABLE "SewerRisingUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_07" ("ID");
+
+CREATE TABLE "SewerRisingUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_08" ("ID");
+
+CREATE TABLE "SewerRisingUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_09" ("ID");
+
+CREATE TABLE "SewerRisingUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerRisingUser_10" ("ID");
+
+CREATE TABLE "SewerStructureUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_01" ("ID");
+
+CREATE TABLE "SewerStructureUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_02" ("ID");
+
+CREATE TABLE "SewerStructureUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_03" ("ID");
+
+CREATE TABLE "SewerStructureUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_04" ("ID");
+
+CREATE TABLE "SewerStructureUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_05" ("ID");
+
+CREATE TABLE "SewerStructureUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_06" ("ID");
+
+CREATE TABLE "SewerStructureUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_07" ("ID");
+
+CREATE TABLE "SewerStructureUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_08" ("ID");
+
+CREATE TABLE "SewerStructureUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_09" ("ID");
+
+CREATE TABLE "SewerStructureUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "SewerStructureUser_10" ("ID");
+
+CREATE TABLE "WaterNodeUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_01" ("ID");
+
+CREATE TABLE "WaterNodeUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_02" ("ID");
+
+CREATE TABLE "WaterNodeUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_03" ("ID");
+
+CREATE TABLE "WaterNodeUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_04" ("ID");
+
+CREATE TABLE "WaterNodeUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_05" ("ID");
+
+CREATE TABLE "WaterNodeUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_06" ("ID");
+
+CREATE TABLE "WaterNodeUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_07" ("ID");
+
+CREATE TABLE "WaterNodeUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_08" ("ID");
+
+CREATE TABLE "WaterNodeUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_09" ("ID");
+
+CREATE TABLE "WaterNodeUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterNodeUser_10" ("ID");
+
+CREATE TABLE "WaterPipeUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_01" ("ID");
+
+CREATE TABLE "WaterPipeUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_02" ("ID");
+
+CREATE TABLE "WaterPipeUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_03" ("ID");
+
+CREATE TABLE "WaterPipeUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_04" ("ID");
+
+CREATE TABLE "WaterPipeUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_05" ("ID");
+
+CREATE TABLE "WaterPipeUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_06" ("ID");
+
+CREATE TABLE "WaterPipeUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_07" ("ID");
+
+CREATE TABLE "WaterPipeUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_08" ("ID");
+
+CREATE TABLE "WaterPipeUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_09" ("ID");
+
+CREATE TABLE "WaterPipeUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPipeUser_10" ("ID");
+
+CREATE TABLE "WaterPumpUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_01" ("ID");
+
+CREATE TABLE "WaterPumpUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_02" ("ID");
+
+CREATE TABLE "WaterPumpUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_03" ("ID");
+
+CREATE TABLE "WaterPumpUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_04" ("ID");
+
+CREATE TABLE "WaterPumpUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_05" ("ID");
+
+CREATE TABLE "WaterPumpUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_06" ("ID");
+
+CREATE TABLE "WaterPumpUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_07" ("ID");
+
+CREATE TABLE "WaterPumpUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_08" ("ID");
+
+CREATE TABLE "WaterPumpUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_09" ("ID");
+
+CREATE TABLE "WaterPumpUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterPumpUser_10" ("ID");
+
+CREATE TABLE "WaterTankUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_01" ("ID");
+
+CREATE TABLE "WaterTankUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_02" ("ID");
+
+CREATE TABLE "WaterTankUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_03" ("ID");
+
+CREATE TABLE "WaterTankUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_04" ("ID");
+
+CREATE TABLE "WaterTankUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_05" ("ID");
+
+CREATE TABLE "WaterTankUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_06" ("ID");
+
+CREATE TABLE "WaterTankUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_07" ("ID");
+
+CREATE TABLE "WaterTankUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_08" ("ID");
+
+CREATE TABLE "WaterTankUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_09" ("ID");
+
+CREATE TABLE "WaterTankUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterTankUser_10" ("ID");
+
+CREATE TABLE "WaterValveUser_01" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_01" ("ID");
+
+CREATE TABLE "WaterValveUser_02" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_02" ("ID");
+
+CREATE TABLE "WaterValveUser_03" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_03" ("ID");
+
+CREATE TABLE "WaterValveUser_04" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_04" ("ID");
+
+CREATE TABLE "WaterValveUser_05" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_05" ("ID");
+
+CREATE TABLE "WaterValveUser_06" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_06" ("ID");
+
+CREATE TABLE "WaterValveUser_07" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_07" ("ID");
+
+CREATE TABLE "WaterValveUser_08" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_08" ("ID");
+
+CREATE TABLE "WaterValveUser_09" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_09" ("ID");
+
+CREATE TABLE "WaterValveUser_10" (
+ "rowid" BIGSERIAL,
+ "Locality" VARCHAR,
+ "MetaID" INTEGER,
+ "ID" UUID,
+ PRIMARY KEY("rowid")
+);
+CREATE UNIQUE INDEX ON "WaterValveUser_10" ("ID");
+
+ALTER TABLE "SewerDiversion_01" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_02" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_03" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_04" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_05" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_06" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_07" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_08" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_09" ADD COLUMN "Link_Code" VARCHAR;
+ALTER TABLE "SewerDiversion_10" ADD COLUMN "Link_Code" VARCHAR;

--- a/schema/main-prev.schema
+++ b/schema/main-prev.schema
@@ -331,6 +331,7 @@ CREATE TABLE "" WaterPipe : WaterBaseLink
 
 	hasone Memo			ID	WaterPipeMemo.ID
 	hasone Results		ID	WaterPipeResult.ID
+	hasone User			ID	WaterPipeUser.ID
 	hasone Timeseries	ID	WaterLinkTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -370,8 +371,9 @@ CREATE TABLE "" WaterPump : WaterBaseLink
  	optional	uuid                From_ID                                         ""
  	optional	uuid                To_ID                                           ""
 
-	hasone Memo		ID	WaterPumpMemo.ID
-	hasone Results	ID	WaterPumpResult.ID
+	hasone Memo			ID	WaterPumpMemo.ID
+	hasone Results		ID	WaterPumpResult.ID
+	hasone User			ID	WaterPumpUser.ID
 	hasone Timeseries	ID	WaterLinkTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -398,6 +400,7 @@ CREATE TABLE "" WaterValve : WaterBaseLink
 
 	hasone Memo			ID	WaterValveMemo.ID
 	hasone Results		ID	WaterValveResult.ID
+	hasone User			ID	WaterValveUser.ID
 	hasone Timeseries	ID	WaterLinkTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -449,8 +452,9 @@ CREATE TABLE "" WaterNode : WaterBaseNode
 	optional	double              Tsim_Percent_Output5                            ""
 	optional	double              Tsim_Initial_Quality                            ""
 
-	hasone Memo		ID	WaterNodeMemo.ID
-	hasone Results	ID	WaterNodeResult.ID
+	hasone Memo			ID	WaterNodeMemo.ID
+	hasone Results		ID	WaterNodeResult.ID
+	hasone User			ID	WaterNodeUser.ID
 	hasone Timeseries	ID	WaterNodeTimeseriesResult.ID
 
 	flags orm_server
@@ -492,6 +496,7 @@ CREATE TABLE "" WaterTank : WaterBaseNode
 
 	hasone Memo			ID	WaterTankMemo.ID
 	hasone Results		ID	WaterTankResult.ID
+	hasone User			ID	WaterTankUser.ID
 	hasone Timeseries	ID	WaterNodeTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -600,7 +605,6 @@ CREATE TABLE "" WaterCurve : WaterBase
 	flags orm_server
 };
 
-
 CREATE TABLE "" WaterPipeMemo : WaterBase
 {
 	"3.Physical"
@@ -649,7 +653,6 @@ CREATE TABLE "" WaterPipeMemo : WaterBase
 	optional	int32               MP_Cost_FN                                      "Masterplan Cost Function"
 	optional	bool                Exists                                          ""
 };
-
 
 CREATE TABLE "" WaterPumpMemo : WaterBase
 {
@@ -706,7 +709,6 @@ CREATE TABLE "" WaterPumpMemo : WaterBase
 	optional	bool                Exists                                          ""
 };
 
-
 CREATE TABLE "" WaterValveMemo : WaterBase
 {
 	"3.Physical"
@@ -756,7 +758,6 @@ CREATE TABLE "" WaterValveMemo : WaterBase
 	optional	bool                Exists                                          ""
 };
 
-
 CREATE TABLE "" WaterNodeMemo : WaterBase
 {
 	"3.Demand.1.Peak Factors"
@@ -801,7 +802,6 @@ CREATE TABLE "" WaterNodeMemo : WaterBase
 	optional	text                AM_Utilization_Integ                            ""
 	optional	bool                Exists                                          ""
 };
-
 
 CREATE TABLE "" WaterTankMemo : WaterBase
 {
@@ -855,6 +855,30 @@ CREATE TABLE "" WaterTankMemo : WaterBase
 	optional	bool                Exists                                          ""
 };
 
+CREATE TABLE "" WaterPipeUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterPumpUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterValveUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterNodeUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterTankUser : WaterBase
+{
+	flags runtime_schema
+};
 
 CREATE TABLE "" WaterPipeResult : WaterBase
 {
@@ -1015,11 +1039,11 @@ CREATE TABLE "WaterNodeTimeseriesResult" WaterNodeTimeseriesResult : WaterBase
 
 CREATE SUFFIX TABLES
 {
-	WaterPipe,		WaterPipeMemo,				WaterPipeResult,
-	WaterPump,		WaterPumpResult,			WaterPumpMemo,
-	WaterValve,		WaterValveResult,			WaterValveMemo,
-	WaterNode,	    WaterNodeResult,	    	WaterNodeMemo,
-	WaterTank,	    WaterTankResult,			WaterTankMemo,
+	WaterPipe,		WaterPipeMemo,				WaterPipeResult,	WaterPipeUser,
+	WaterPump,		WaterPumpResult,			WaterPumpMemo,		WaterPumpUser,
+	WaterValve,		WaterValveResult,			WaterValveMemo,		WaterValveUser,
+	WaterNode,	    WaterNodeResult,	    	WaterNodeMemo,		WaterNodeUser,
+	WaterTank,	    WaterTankResult,			WaterTankMemo,		WaterTankUser,
 	WaterSpecial,   WaterProject,           	WaterUnit, 
 	WaterCurve, 	WaterLinkTimeseriesResult, 	WaterNodeTimeseriesResult;
 	01, 02, 03, 04, 05, 06, 07, 08, 09, 10;
@@ -1663,6 +1687,7 @@ CREATE TABLE "" SewerGravity : SewerBaseLink
 
 	hasone 		Memo				ID				SewerGravityMemo.ID
 	hasone 		Results				ID				SewerGravityResults.ID
+	hasone		User 				ID				SewerGravityUser.ID
 	hasmany		Work_Orders			ID				HydroJetWorkOrder.PipeID			module:Sewer		order:6
 	hasone		Pipe 				Link_Code		SpimPipe.PipeCode
 
@@ -1722,6 +1747,10 @@ CREATE TABLE "" SewerGravityMemo : SewerBase
 	optional  text                AM_ID_No                                         "Asset Management ID Number"
 	optional  double              AM_Utilization                                   "Asset Management Utilization"
 	optional  text                AM_Utilization_Integ                             "Asset Management Utilization Integrity"
+
+	# NOTE: The following block of fields (down to Cctv_Material) must be removed, now
+	# that we have the SewerGravityUser table. The reason we're leaving them in for now,
+	# is for backward compatibility sake.
 	optional  double              GIS_Diameter                                     "GIS Diameter"
 	optional  text                GIS_Gradient                                     "GIS Gradient"
 	optional  text                Old_GIS_ID                                       "Old GIS ID"
@@ -1734,6 +1763,11 @@ CREATE TABLE "" SewerGravityMemo : SewerBase
 	optional  text                Cctv_Material                                    "Cctv Material"
 
 	flags orm_server
+};
+
+CREATE TABLE "" SewerGravityUser : SewerBase
+{
+	flags runtime_schema
 };
 
 CREATE TABLE "" SewerGravityResults : SewerBase
@@ -1789,8 +1823,9 @@ CREATE TABLE "" SewerDiversion : SewerBase
 	optional  uuid                From_ID                                     	  ""
 	optional  uuid                To_ID                                       	  ""
 	"1.Topology"
-	optional  text                From_Structure_Code                             "From Structure Code"																uiorder:1
-	optional  text                To_Structure_Code                               "To Structure Code"																uiorder:2
+	optional  text                Link_Code                                       "Link Code"								tags:humanID							uiorder:1
+	optional  text                From_Structure_Code                             "From Structure Code"																uiorder:2
+	optional  text                To_Structure_Code                               "To Structure Code"																uiorder:3
 	"2.Hydraulic"
 	optional  double              Percent_Of_Flow_1                               "Flow Percentage 1"						unit:%									uiorder:1
 	optional  double              Flow_1                                          "Flow1"									unit:L/s								uiorder:2
@@ -1812,6 +1847,11 @@ CREATE TABLE "" SewerDiversion : SewerBase
 	optional  double              Flow_9                                          "Flow9"									unit:L/s								uiorder:18
 	optional  double              Percent_Of_Flow_10                              "Flow Percentage 10"						unit:%									uiorder:19
 	optional  double              Flow_10                                         "Flow10"									unit:L/s								uiorder:20
+};
+
+CREATE TABLE "" SewerDiversionUser : SewerBase
+{
+	flags runtime_schema
 };
 
 CREATE TABLE "" SewerPump : SewerBase
@@ -1858,6 +1898,7 @@ CREATE TABLE "" SewerPump : SewerBase
 
 	hasone Memo		ID	SewerPumpMemo.ID
 	hasone Results	ID	SewerPumpResults.ID
+	hasone User	    ID  SewerPumpUser.ID
 };
 
 CREATE TABLE "" SewerPumpMemo : SewerBase
@@ -1912,6 +1953,11 @@ CREATE TABLE "" SewerPumpMemo : SewerBase
 	optional  text                AM_Utilization_Integ		                      "Asset Management Utilization Integrity"
 };
 
+CREATE TABLE "" SewerPumpUser : SewerBase
+{
+	flags runtime_schema
+};
+
 CREATE TABLE "" SewerPumpResults : SewerBase
 {
 	"6.Results.1.Sewer Flow"
@@ -1959,6 +2005,7 @@ CREATE TABLE "" SewerRising : SewerBaseLink
 
 	hasone 		Memo					ID				SewerRisingMemo.ID
 	hasone 		Results					ID				SewerRisingResults.ID
+	hasone		User 					ID				SewerRisingUser.ID
 	hasone		Pipe 					Link_Code		SpimPipe.PipeCode
 }
 INDEX(Geometry)
@@ -2009,9 +2056,12 @@ CREATE TABLE "" SewerRisingMemo : SewerBase
 	optional  text                Year_Integrity                                  "Year Integrity"																	uiorder:5
 	optional  text                Drawing_No                                      "Drawing Number"																	uiorder:6
 	"Internal"
+	
+	# NOTE: The following 3 fields (down to Old_GIS_Int) should be deleted, now that we have SewerRisingUser
 	optional  double              GIS_Diameter                                    "GIS Diameter"
 	optional  text                Old_GIS_ID                                      "Old GIS ID"
 	optional  text                Old_GIS_Int                                     "Old GIS Int"
+
 	optional  text                MP_Design_Type                                  "Masterplan Design Type"
 	optional  text                MP_Cost_Detail                                  "Masterplan Cost Detail"
 	optional  int32               MP_Cost_FN                                      "Masterplan Cost Function"
@@ -2019,6 +2069,11 @@ CREATE TABLE "" SewerRisingMemo : SewerBase
 	optional  text                AM_ID_No                                        "Asset Management ID Number"
 	optional  double              AM_Utilization                                  "Asset Management Utilization"
 	optional  text                AM_Utilization_Integ                            "Asset Management Utilization Integrity"
+};
+
+CREATE TABLE "" SewerRisingUser : SewerBase
+{
+	flags runtime_schema
 };
 
 CREATE TABLE "" SewerRisingResults : SewerBase
@@ -2126,6 +2181,7 @@ CREATE TABLE "" SewerStructure : SewerBaseNode
 	hasone    Scenario2    ID	SewerScenario2.ID
 	hasone    Scenario3    ID	SewerScenario3.ID
 	hasone    Memo         ID	SewerStructureMemo.ID
+	hasone    User 	       ID   SewerStructureUser.ID
 	hasone    Results      ID	SewerStructureResults.ID
 	hasone    Pumps        ID	SewerPump.From_ID																													order:5
 	hasone    Diversion    ID	SewerDiversion.From_ID																												order:6
@@ -2195,6 +2251,12 @@ CREATE TABLE "" SewerStructureMemo : SewerBase
 	hasone TshwaneData		ID	SewerStructureMemoTshwane.ID
 };
 
+CREATE TABLE "" SewerStructureUser : SewerBase
+{
+	flags runtime_schema
+};
+
+# NOTE: Now that we have SewerStructureUser, we should get rid of SewerStructureMemoTshwane
 CREATE TABLE "" SewerStructureMemoTshwane : SewerBase
 {
 	"10.Integrity"
@@ -2300,12 +2362,13 @@ INDEX(Geometry);
 
 CREATE SUFFIX TABLES
 {
-	SewerGravity,	  SewerGravityMemo,		SewerGravityResults,
-	SewerRising,	  SewerRisingMemo,		SewerRisingResults,
-	SewerStructure,	  SewerStructureMemo,	SewerStructureResults,
-	SewerPump,		  SewerPumpMemo,		SewerPumpResults,
+	SewerGravity,	  SewerGravityMemo,		SewerGravityResults,	SewerGravityUser,
+	SewerRising,	  SewerRisingMemo,		SewerRisingResults,		SewerRisingUser,
+	SewerStructure,	  SewerStructureMemo,	SewerStructureResults,	SewerStructureUser,
+	SewerPump,		  SewerPumpMemo,		SewerPumpResults,		SewerPumpUser,
 	SewerScenario1,	  SewerScenario2,		SewerScenario3,
-	SewerDiversion,   SewerStructureMemoTshwane, SewerAppurtenances;
+	SewerDiversion,   SewerDiversionUser,
+	SewerStructureMemoTshwane, SewerAppurtenances;
 	01, 02, 03, 04, 05, 06, 07, 08, 09, 10;
 };
 

--- a/schema/main.schema
+++ b/schema/main.schema
@@ -331,6 +331,7 @@ CREATE TABLE "" WaterPipe : WaterBaseLink
 
 	hasone Memo			ID	WaterPipeMemo.ID
 	hasone Results		ID	WaterPipeResult.ID
+	hasone User			ID	WaterPipeUser.ID
 	hasone Timeseries	ID	WaterLinkTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -370,8 +371,9 @@ CREATE TABLE "" WaterPump : WaterBaseLink
  	optional	uuid                From_ID                                         ""
  	optional	uuid                To_ID                                           ""
 
-	hasone Memo		ID	WaterPumpMemo.ID
-	hasone Results	ID	WaterPumpResult.ID
+	hasone Memo			ID	WaterPumpMemo.ID
+	hasone Results		ID	WaterPumpResult.ID
+	hasone User			ID	WaterPumpUser.ID
 	hasone Timeseries	ID	WaterLinkTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -398,6 +400,7 @@ CREATE TABLE "" WaterValve : WaterBaseLink
 
 	hasone Memo			ID	WaterValveMemo.ID
 	hasone Results		ID	WaterValveResult.ID
+	hasone User			ID	WaterValveUser.ID
 	hasone Timeseries	ID	WaterLinkTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -449,8 +452,9 @@ CREATE TABLE "" WaterNode : WaterBaseNode
 	optional	double              Tsim_Percent_Output5                            ""
 	optional	double              Tsim_Initial_Quality                            ""
 
-	hasone Memo		ID	WaterNodeMemo.ID
-	hasone Results	ID	WaterNodeResult.ID
+	hasone Memo			ID	WaterNodeMemo.ID
+	hasone Results		ID	WaterNodeResult.ID
+	hasone User			ID	WaterNodeUser.ID
 	hasone Timeseries	ID	WaterNodeTimeseriesResult.ID
 
 	flags orm_server
@@ -492,6 +496,7 @@ CREATE TABLE "" WaterTank : WaterBaseNode
 
 	hasone Memo			ID	WaterTankMemo.ID
 	hasone Results		ID	WaterTankResult.ID
+	hasone User			ID	WaterTankUser.ID
 	hasone Timeseries	ID	WaterNodeTimeseriesResult.ID
 }
 INDEX(Geometry);
@@ -600,7 +605,6 @@ CREATE TABLE "" WaterCurve : WaterBase
 	flags orm_server
 };
 
-
 CREATE TABLE "" WaterPipeMemo : WaterBase
 {
 	"3.Physical"
@@ -649,7 +653,6 @@ CREATE TABLE "" WaterPipeMemo : WaterBase
 	optional	int32               MP_Cost_FN                                      "Masterplan Cost Function"
 	optional	bool                Exists                                          ""
 };
-
 
 CREATE TABLE "" WaterPumpMemo : WaterBase
 {
@@ -706,7 +709,6 @@ CREATE TABLE "" WaterPumpMemo : WaterBase
 	optional	bool                Exists                                          ""
 };
 
-
 CREATE TABLE "" WaterValveMemo : WaterBase
 {
 	"3.Physical"
@@ -756,7 +758,6 @@ CREATE TABLE "" WaterValveMemo : WaterBase
 	optional	bool                Exists                                          ""
 };
 
-
 CREATE TABLE "" WaterNodeMemo : WaterBase
 {
 	"3.Demand.1.Peak Factors"
@@ -801,7 +802,6 @@ CREATE TABLE "" WaterNodeMemo : WaterBase
 	optional	text                AM_Utilization_Integ                            ""
 	optional	bool                Exists                                          ""
 };
-
 
 CREATE TABLE "" WaterTankMemo : WaterBase
 {
@@ -855,6 +855,30 @@ CREATE TABLE "" WaterTankMemo : WaterBase
 	optional	bool                Exists                                          ""
 };
 
+CREATE TABLE "" WaterPipeUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterPumpUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterValveUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterNodeUser : WaterBase
+{
+	flags runtime_schema
+};
+
+CREATE TABLE "" WaterTankUser : WaterBase
+{
+	flags runtime_schema
+};
 
 CREATE TABLE "" WaterPipeResult : WaterBase
 {
@@ -1015,11 +1039,11 @@ CREATE TABLE "WaterNodeTimeseriesResult" WaterNodeTimeseriesResult : WaterBase
 
 CREATE SUFFIX TABLES
 {
-	WaterPipe,		WaterPipeMemo,				WaterPipeResult,
-	WaterPump,		WaterPumpResult,			WaterPumpMemo,
-	WaterValve,		WaterValveResult,			WaterValveMemo,
-	WaterNode,	    WaterNodeResult,	    	WaterNodeMemo,
-	WaterTank,	    WaterTankResult,			WaterTankMemo,
+	WaterPipe,		WaterPipeMemo,				WaterPipeResult,	WaterPipeUser,
+	WaterPump,		WaterPumpResult,			WaterPumpMemo,		WaterPumpUser,
+	WaterValve,		WaterValveResult,			WaterValveMemo,		WaterValveUser,
+	WaterNode,	    WaterNodeResult,	    	WaterNodeMemo,		WaterNodeUser,
+	WaterTank,	    WaterTankResult,			WaterTankMemo,		WaterTankUser,
 	WaterSpecial,   WaterProject,           	WaterUnit, 
 	WaterCurve, 	WaterLinkTimeseriesResult, 	WaterNodeTimeseriesResult;
 	01, 02, 03, 04, 05, 06, 07, 08, 09, 10;
@@ -1663,6 +1687,7 @@ CREATE TABLE "" SewerGravity : SewerBaseLink
 
 	hasone 		Memo				ID				SewerGravityMemo.ID
 	hasone 		Results				ID				SewerGravityResults.ID
+	hasone		User 				ID				SewerGravityUser.ID
 	hasmany		Work_Orders			ID				HydroJetWorkOrder.PipeID			module:Sewer		order:6
 	hasone		Pipe 				Link_Code		SpimPipe.PipeCode
 
@@ -1722,6 +1747,10 @@ CREATE TABLE "" SewerGravityMemo : SewerBase
 	optional  text                AM_ID_No                                         "Asset Management ID Number"
 	optional  double              AM_Utilization                                   "Asset Management Utilization"
 	optional  text                AM_Utilization_Integ                             "Asset Management Utilization Integrity"
+
+	# NOTE: The following block of fields (down to Cctv_Material) must be removed, now
+	# that we have the SewerGravityUser table. The reason we're leaving them in for now,
+	# is for backward compatibility sake.
 	optional  double              GIS_Diameter                                     "GIS Diameter"
 	optional  text                GIS_Gradient                                     "GIS Gradient"
 	optional  text                Old_GIS_ID                                       "Old GIS ID"
@@ -1734,6 +1763,11 @@ CREATE TABLE "" SewerGravityMemo : SewerBase
 	optional  text                Cctv_Material                                    "Cctv Material"
 
 	flags orm_server
+};
+
+CREATE TABLE "" SewerGravityUser : SewerBase
+{
+	flags runtime_schema
 };
 
 CREATE TABLE "" SewerGravityResults : SewerBase
@@ -1789,8 +1823,9 @@ CREATE TABLE "" SewerDiversion : SewerBase
 	optional  uuid                From_ID                                     	  ""
 	optional  uuid                To_ID                                       	  ""
 	"1.Topology"
-	optional  text                From_Structure_Code                             "From Structure Code"																uiorder:1
-	optional  text                To_Structure_Code                               "To Structure Code"																uiorder:2
+	optional  text                Link_Code                                       "Link Code"								tags:humanID							uiorder:1
+	optional  text                From_Structure_Code                             "From Structure Code"																uiorder:2
+	optional  text                To_Structure_Code                               "To Structure Code"																uiorder:3
 	"2.Hydraulic"
 	optional  double              Percent_Of_Flow_1                               "Flow Percentage 1"						unit:%									uiorder:1
 	optional  double              Flow_1                                          "Flow1"									unit:L/s								uiorder:2
@@ -1812,6 +1847,11 @@ CREATE TABLE "" SewerDiversion : SewerBase
 	optional  double              Flow_9                                          "Flow9"									unit:L/s								uiorder:18
 	optional  double              Percent_Of_Flow_10                              "Flow Percentage 10"						unit:%									uiorder:19
 	optional  double              Flow_10                                         "Flow10"									unit:L/s								uiorder:20
+};
+
+CREATE TABLE "" SewerDiversionUser : SewerBase
+{
+	flags runtime_schema
 };
 
 CREATE TABLE "" SewerPump : SewerBase
@@ -1858,6 +1898,7 @@ CREATE TABLE "" SewerPump : SewerBase
 
 	hasone Memo		ID	SewerPumpMemo.ID
 	hasone Results	ID	SewerPumpResults.ID
+	hasone User	    ID  SewerPumpUser.ID
 };
 
 CREATE TABLE "" SewerPumpMemo : SewerBase
@@ -1912,6 +1953,11 @@ CREATE TABLE "" SewerPumpMemo : SewerBase
 	optional  text                AM_Utilization_Integ		                      "Asset Management Utilization Integrity"
 };
 
+CREATE TABLE "" SewerPumpUser : SewerBase
+{
+	flags runtime_schema
+};
+
 CREATE TABLE "" SewerPumpResults : SewerBase
 {
 	"6.Results.1.Sewer Flow"
@@ -1959,6 +2005,7 @@ CREATE TABLE "" SewerRising : SewerBaseLink
 
 	hasone 		Memo					ID				SewerRisingMemo.ID
 	hasone 		Results					ID				SewerRisingResults.ID
+	hasone		User 					ID				SewerRisingUser.ID
 	hasone		Pipe 					Link_Code		SpimPipe.PipeCode
 }
 INDEX(Geometry)
@@ -2009,9 +2056,12 @@ CREATE TABLE "" SewerRisingMemo : SewerBase
 	optional  text                Year_Integrity                                  "Year Integrity"																	uiorder:5
 	optional  text                Drawing_No                                      "Drawing Number"																	uiorder:6
 	"Internal"
+	
+	# NOTE: The following 3 fields (down to Old_GIS_Int) should be deleted, now that we have SewerRisingUser
 	optional  double              GIS_Diameter                                    "GIS Diameter"
 	optional  text                Old_GIS_ID                                      "Old GIS ID"
 	optional  text                Old_GIS_Int                                     "Old GIS Int"
+
 	optional  text                MP_Design_Type                                  "Masterplan Design Type"
 	optional  text                MP_Cost_Detail                                  "Masterplan Cost Detail"
 	optional  int32               MP_Cost_FN                                      "Masterplan Cost Function"
@@ -2019,6 +2069,11 @@ CREATE TABLE "" SewerRisingMemo : SewerBase
 	optional  text                AM_ID_No                                        "Asset Management ID Number"
 	optional  double              AM_Utilization                                  "Asset Management Utilization"
 	optional  text                AM_Utilization_Integ                            "Asset Management Utilization Integrity"
+};
+
+CREATE TABLE "" SewerRisingUser : SewerBase
+{
+	flags runtime_schema
 };
 
 CREATE TABLE "" SewerRisingResults : SewerBase
@@ -2126,6 +2181,7 @@ CREATE TABLE "" SewerStructure : SewerBaseNode
 	hasone    Scenario2    ID	SewerScenario2.ID
 	hasone    Scenario3    ID	SewerScenario3.ID
 	hasone    Memo         ID	SewerStructureMemo.ID
+	hasone    User 	       ID   SewerStructureUser.ID
 	hasone    Results      ID	SewerStructureResults.ID
 	hasone    Pumps        ID	SewerPump.From_ID																													order:5
 	hasone    Diversion    ID	SewerDiversion.From_ID																												order:6
@@ -2195,6 +2251,12 @@ CREATE TABLE "" SewerStructureMemo : SewerBase
 	hasone TshwaneData		ID	SewerStructureMemoTshwane.ID
 };
 
+CREATE TABLE "" SewerStructureUser : SewerBase
+{
+	flags runtime_schema
+};
+
+# NOTE: Now that we have SewerStructureUser, we should get rid of SewerStructureMemoTshwane
 CREATE TABLE "" SewerStructureMemoTshwane : SewerBase
 {
 	"10.Integrity"
@@ -2300,12 +2362,13 @@ INDEX(Geometry);
 
 CREATE SUFFIX TABLES
 {
-	SewerGravity,	  SewerGravityMemo,		SewerGravityResults,
-	SewerRising,	  SewerRisingMemo,		SewerRisingResults,
-	SewerStructure,	  SewerStructureMemo,	SewerStructureResults,
-	SewerPump,		  SewerPumpMemo,		SewerPumpResults,
+	SewerGravity,	  SewerGravityMemo,		SewerGravityResults,	SewerGravityUser,
+	SewerRising,	  SewerRisingMemo,		SewerRisingResults,		SewerRisingUser,
+	SewerStructure,	  SewerStructureMemo,	SewerStructureResults,	SewerStructureUser,
+	SewerPump,		  SewerPumpMemo,		SewerPumpResults,		SewerPumpUser,
 	SewerScenario1,	  SewerScenario2,		SewerScenario3,
-	SewerDiversion,   SewerStructureMemoTshwane, SewerAppurtenances;
+	SewerDiversion,   SewerDiversionUser,
+	SewerStructureMemoTshwane, SewerAppurtenances;
 	01, 02, 03, 04, 05, 06, 07, 08, 09, 10;
 };
 


### PR DESCRIPTION
For example, we now have:

WaterPipe, WaterPipeMemo, WaterPipeResult, AND WaterPipeUser

... and same for Sewer

The -User tables have only the 3 basic fields rowid, MetaID, and ID.
But crucially, they have the runtime_schema flag on them.

I've tested this migration with the COU data, and it all works out
of the box.

I followed the recommendations that Johann Rudolph gave us in his
email from 2018-04-13, including the addition of a Link_Code field
to SewerDiversion.

The crucial things that I did not include from Johann's email,
was the 4 new fields that he wanted in the Swift tables, for
drought monitoring. What we want to do instead, is to add user
tables for Swift too, but I'll leave that as future work.