### PR TITLE
Remove wrong fully created table, data properly mapped to rainfall

### DIFF
--- a/migrations/main/2019-05-23-remove-raingage-table.sql
+++ b/migrations/main/2019-05-23-remove-raingage-table.sql
@@ -1,0 +1,10 @@
+DROP TABLE "StormWaterRainGage_01";
+DROP TABLE "StormWaterRainGage_02";
+DROP TABLE "StormWaterRainGage_03";
+DROP TABLE "StormWaterRainGage_04";
+DROP TABLE "StormWaterRainGage_05";
+DROP TABLE "StormWaterRainGage_06";
+DROP TABLE "StormWaterRainGage_07";
+DROP TABLE "StormWaterRainGage_08";
+DROP TABLE "StormWaterRainGage_09";
+DROP TABLE "StormWaterRainGage_10";

--- a/schema/main-prev.schema
+++ b/schema/main-prev.schema
@@ -4725,19 +4725,6 @@ CREATE TABLE "" StormWaterConduitResults : StormWaterBaseID
 
 };
 
-CREATE TABLE "" StormWaterRainGage : StormWaterBaseID
-{
-	"Internal"
-	optional	point				Geometry				"Geometry"
-	optional	text				Code					"Code"
-	optional	text				Format					"Format"
-	optional	text				Interval				"Interval"
-	optional	double				SCF						"SCF"
-	optional	text				DataSource				"DataSource"
-
-}
-INDEX(Geometry);
-
 CREATE TABLE "" StormwaterCatchment : StormWaterBaseID
 {
 	"Internal"
@@ -5659,8 +5646,7 @@ CREATE SUFFIX TABLES
 	StormwaterDivider,		StormwaterDividerMemo,				StormwaterDividerResults,	StormwaterDividerUser,
 	StormwaterOutfall,		StormwaterOutfallMemo,				StormwaterOutfallResults,	StormwaterOutfallUser,
 	StormwaterRainfall,		StormwaterRainfallMemo,				StormwaterRainfallUser,
-	StormSchematicTransectionCurrent,	StormSchematicCurveCurrent,
-	StormWaterRainGage;
+	StormSchematicTransectionCurrent,	StormSchematicCurveCurrent;
 	01, 02, 03, 04, 05, 06, 07, 08, 09, 10;
 };
 

--- a/schema/main.schema
+++ b/schema/main.schema
@@ -4725,19 +4725,6 @@ CREATE TABLE "" StormWaterConduitResults : StormWaterBaseID
 
 };
 
-CREATE TABLE "" StormWaterRainGage : StormWaterBaseID
-{
-	"Internal"
-	optional	point				Geometry				"Geometry"
-	optional	text				Code					"Code"
-	optional	text				Format					"Format"
-	optional	text				Interval				"Interval"
-	optional	double				SCF						"SCF"
-	optional	text				DataSource				"DataSource"
-
-}
-INDEX(Geometry);
-
 CREATE TABLE "" StormwaterCatchment : StormWaterBaseID
 {
 	"Internal"
@@ -5659,8 +5646,7 @@ CREATE SUFFIX TABLES
 	StormwaterDivider,		StormwaterDividerMemo,				StormwaterDividerResults,	StormwaterDividerUser,
 	StormwaterOutfall,		StormwaterOutfallMemo,				StormwaterOutfallResults,	StormwaterOutfallUser,
 	StormwaterRainfall,		StormwaterRainfallMemo,				StormwaterRainfallUser,
-	StormSchematicTransectionCurrent,	StormSchematicCurveCurrent,
-	StormWaterRainGage;
+	StormSchematicTransectionCurrent,	StormSchematicCurveCurrent;
 	01, 02, 03, 04, 05, 06, 07, 08, 09, 10;
 };
 


### PR DESCRIPTION
I wrongfully created this table because I missed something in our schema. So I'm cleaning it up here and in the importer https://github.com/IMQS/maps/pull/151 . The data hasnt gone beyond QA so no changes up the stream other than deleting the table.